### PR TITLE
added gitignore file - administrative stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Git stuff
+
+# MacOS Stuff
+.DS_Store
+
+# tmp files
+*.tmp


### PR DESCRIPTION
Added this for some compatibility sake and to prevent dumb things from being committed (don't want temp files and sysos files being synced).

Does anyone know a good way to prevent binaries from being uploaded? Other than excluding things like *.exe...I'm not sure.

We should consider adding *.exe exclusion in any case.